### PR TITLE
Removed extra console commands, defaulted webbrowser_f1_open to 0, and added hint text for commands.

### DIFF
--- a/lua/autorun/client/webbrowser.lua
+++ b/lua/autorun/client/webbrowser.lua
@@ -449,10 +449,8 @@ local function webbrowser(a, b, c, line)
 	ShowPanel(url)
 end
 
-concommand.Add("webbrowser", webbrowser, nil)
-concommand.Add("browser", webbrowser, nil)
-concommand.Add("open", webbrowser, nil)
-local webbrowser_f1_open = CreateClientConVar("webbrowser_f1_open", "1", true)
+concommand.Add("webbrowser_open", webbrowser, nil)
+local webbrowser_f1_open = CreateClientConVar("webbrowser_f1_open", "0", true)
 local f1key = input.LookupKeyBinding(KEY_F1)
 
 local rec

--- a/lua/autorun/client/webbrowser.lua
+++ b/lua/autorun/client/webbrowser.lua
@@ -420,7 +420,7 @@ local function ShowPanel(url)
 	return webbrowser_panel
 end
 
-local webbrowser_enabled = CreateClientConVar("webbrowser_enabled", "0", true)
+local webbrowser_enabled = CreateClientConVar("webbrowser_enabled", "0", true, false, "Displays the glua_utilities webbrowser.")
 local mediaurls = {"mp4"} -- File extensions that shouldn't be opened with ingame browser.
 gui.OLDOpenURL = gui.OLDOpenURL or gui.OpenURL
 
@@ -449,8 +449,8 @@ local function webbrowser(a, b, c, line)
 	ShowPanel(url)
 end
 
-concommand.Add("webbrowser_open", webbrowser, nil)
-local webbrowser_f1_open = CreateClientConVar("webbrowser_f1_open", "0", true)
+concommand.Add("webbrowser_open", webbrowser, nil, "Opens the glua_utilities web browser.")
+local webbrowser_f1_open = CreateClientConVar("webbrowser_f1_open", "0", true, false, "Allows F1 to open the glua_utilities web browser.")
 local f1key = input.LookupKeyBinding(KEY_F1)
 
 local rec


### PR DESCRIPTION
This script is a core component of Outfitter, and it has been frustrating to play any gamemode that requires the function keys, as pressing F1 to open a menu instead opens up a web browser. It took a fair bit of research to even find that there was a ConVar that controlled the window appearing. [The one GitHub issue mentioning it](https://github.com/Metastruct/outfitter/issues/52#issuecomment-722038666) said it was changed to be disabled by default, but this wasn't the case. This PR enforces the change while removing duplicate console commands.